### PR TITLE
SOLID SoundManager refactor

### DIFF
--- a/traffic/build.gradle.kts
+++ b/traffic/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation ("org.jetbrains:annotations:16.0.2")
 }
 application {
-     mainClass = "be.ecam.trafficsim.Simulation"
+     mainClass = "be.ecam.trafficsim.Main"
 }
 tasks.test {
     useJUnitPlatform()

--- a/traffic/src/main/java/be/ecam/trafficsim/Main.java
+++ b/traffic/src/main/java/be/ecam/trafficsim/Main.java
@@ -15,12 +15,20 @@ public class Main {
         jF.setSize(1366, 750);
         jF.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         jF.setVisible(true);
-        Map<String, InputStream> sounds = Map.of(
-                "traffic", Objects.requireNonNull(Main.class.getResourceAsStream("/Traffic Sounds - Free Sound Effects - Traffic Sound Clips - Sound Bites.wav")),
-                "drift", Objects.requireNonNull(Main.class.getResourceAsStream("/drift.wav"))
-        );
+
+        Map<String, InputStream> sounds = null;
+        try {
+            sounds = Map.of(
+                    "traffic", Objects.requireNonNull(Main.class.getResourceAsStream("/Traffic Sounds - Free Sound Effects - Traffic Sound Clips - Sound Bites.wav")),
+                    "drift", Objects.requireNonNull(Main.class.getResourceAsStream(""))
+            );
+        } catch (NullPointerException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
         final SoundManager soundManager = new SoundManager(sounds);
         soundManager.play();
+
         jF.addWindowListener(new WindowListener() {
             public void windowOpened(WindowEvent e) {
             }

--- a/traffic/src/main/java/be/ecam/trafficsim/Main.java
+++ b/traffic/src/main/java/be/ecam/trafficsim/Main.java
@@ -3,6 +3,9 @@ package be.ecam.trafficsim;
 import javax.swing.*;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
 
 public class Main {
     public static void main(String[] args) {
@@ -12,7 +15,11 @@ public class Main {
         jF.setSize(1366, 750);
         jF.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         jF.setVisible(true);
-        final SoundManager soundManager = new SoundManager();
+        Map<String, InputStream> sounds = Map.of(
+                "traffic", Objects.requireNonNull(Main.class.getResourceAsStream("/Traffic Sounds - Free Sound Effects - Traffic Sound Clips - Sound Bites.wav")),
+                "drift", Objects.requireNonNull(Main.class.getResourceAsStream("/drift.wav"))
+        );
+        final SoundManager soundManager = new SoundManager(sounds);
         soundManager.play();
         jF.addWindowListener(new WindowListener() {
             public void windowOpened(WindowEvent e) {

--- a/traffic/src/main/java/be/ecam/trafficsim/Main.java
+++ b/traffic/src/main/java/be/ecam/trafficsim/Main.java
@@ -20,7 +20,7 @@ public class Main {
         try {
             sounds = Map.of(
                     "traffic", Objects.requireNonNull(Main.class.getResourceAsStream("/Traffic Sounds - Free Sound Effects - Traffic Sound Clips - Sound Bites.wav")),
-                    "drift", Objects.requireNonNull(Main.class.getResourceAsStream(""))
+                    "drift", Objects.requireNonNull(Main.class.getResourceAsStream("/drift.wav"))
             );
         } catch (NullPointerException e) {
             System.err.println(e.getMessage());

--- a/traffic/src/main/java/be/ecam/trafficsim/SoundManager.java
+++ b/traffic/src/main/java/be/ecam/trafficsim/SoundManager.java
@@ -3,18 +3,19 @@ package be.ecam.trafficsim;
 import javax.sound.sampled.*;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Objects;
+import java.io.InputStream;
+import java.util.Map;
 
 public class SoundManager implements Closeable {
     private final Clip clip;
     private final Clip driftClip;
 
-    public SoundManager() {
+    public SoundManager(Map<String, InputStream> inputs) {
         Clip clip = null;
         Clip driftClip = null;
         try {
-            AudioInputStream inputStream = AudioSystem.getAudioInputStream(Objects.requireNonNull(getClass().getResourceAsStream("/Traffic Sounds - Free Sound Effects - Traffic Sound Clips - Sound Bites.wav")));
-            AudioInputStream driftStream = AudioSystem.getAudioInputStream(Objects.requireNonNull(getClass().getResourceAsStream("/drift.wav")));
+            AudioInputStream inputStream = AudioSystem.getAudioInputStream(inputs.get("traffic"));
+            AudioInputStream driftStream = AudioSystem.getAudioInputStream(inputs.get("drift"));
             clip = AudioSystem.getClip();
             driftClip = AudioSystem.getClip();
             clip.open(inputStream);


### PR DESCRIPTION
Remove audio filenames from the `SoundManager` class to rather have them as parameter of the constructor.
Also created a `Map` object storing them to be pass as parameter in `Main.java`.